### PR TITLE
Replace tokio_util::sync::CancellationToken with futures_util::future::Abortable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
  "camino",
  "clap",
  "futures",
+ "futures-util",
  "snapbox",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bytes = "1"
 camino = "1"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
+futures-util = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-serial = "5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use tokio_serial::SerialPortBuilderExt;
 use tokio_serial::{SerialPort, SerialStream};
 use tokio_stream::{StreamExt, StreamMap};
 use tokio_util::io::ReaderStream;
-use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use std::collections::HashMap;
@@ -93,32 +92,25 @@ pub async fn transfer<R, W>(
     mut sources: StreamMap<String, ReaderStream<R>>,
     mut sinks: HashMap<String, W>,
     routes: HashMap<String, Vec<String>>,
-    shutdown_token: CancellationToken,
 ) -> Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    loop {
-        tokio::select! {
-            next = sources.next() => {
-                let (src_id, result) = next.ok_or(Error::Closed)?;
-                if let Some(dst_ids) = routes.get(&src_id) {
-                    let bytes = result.map_err(Error::Read)?;
-                    info!(?src_id, ?dst_ids, ?bytes, "read");
-                    for dst_id in dst_ids {
-                        // This unwrap is OK as long as we validate all route IDs exist first
-                        // Route IDs are validated in Args::check_route_ids()
-                        let dst = sinks.get_mut(dst_id).unwrap();
-                        let mut buf = bytes.clone();
-                        dst.write_all_buf(&mut buf).await.map_err(Error::Write)?;
-                        info!(?dst_id, ?bytes, "wrote");
-                    }
-                }
-            }
-            _ = shutdown_token.cancelled() => {
-                return Ok(());
+    while let Some((src_id, result)) = sources.next().await {
+        if let Some(dst_ids) = routes.get(&src_id) {
+            let bytes = result.map_err(Error::Read)?;
+            info!(?src_id, ?dst_ids, ?bytes, "read");
+            for dst_id in dst_ids {
+                // This unwrap is OK as long as we validate all route IDs exist first
+                // Route IDs are validated in Args::check_route_ids()
+                let dst = sinks.get_mut(dst_id).unwrap();
+                let mut buf = bytes.clone();
+                dst.write_all_buf(&mut buf).await.map_err(Error::Write)?;
+                info!(?dst_id, ?bytes, "wrote");
             }
         }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
This simplifies the transfer function since it no longer needs to known about cancellation.