### PR TITLE
Prevent blocking all virtual serial ports on full PTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ In terminal 2
 picocom 2
 ```
 
-Characters entered in terminal 0 will be sent to terminal 2 only.
-Characters entered in terminal 1 will be sent to terminal 2 only.
+Characters entered in terminal 0 will be sent to terminal 2 only.\
+Characters entered in terminal 1 will be sent to terminal 2 only.\
 Characters entered in terminal 2 will be sent to both terminals 0 and 1.
 
 ## Connection to a Virtual Serial Port

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Characters entered in terminal 0 will be sent to terminal 2 only.
 Characters entered in terminal 1 will be sent to terminal 2 only.
 Characters entered in terminal 2 will be sent to both terminals 0 and 1.
 
+## Connection to a Virtual Serial Port
+
+Virtual serial ports created by vsp-router behave a bit differently from physical serial ports:
+* You can connect to them using any baud rate. You are not forced to use the same baud rate as the physical serial port you are multiplexing.
+* When you don't read from them they accumulate data in a buffer. When this buffer becomes full new data will be discarded and a warning message will be shown in the logs. Any buffered data will get returned when you next read from them.
+
+To avoid reading stale data accumulated in the buffer when you want to read from the virtual serial port it is recommended to flush its input buffer before you first read from it. This can be done using `tcflush(fd, TCIFLUSH)` (or equivalent on your platform) on the file descriptor of the virtual serial port.
+
 ## Comparison to TTYBUS
 
 vsp-router is similar to [TTYBUS](https://github.com/danielinux/ttybus).


### PR DESCRIPTION
I am running the following command to multiplex a serial port into multiple virtual serial ports:

```sh
vsp-router \
  --attach gps0:/dev/ttyUSB0,9600 \
  --create /dev/gps0_gpsd \
  --create /dev/gps0_data \
  --create /dev/gps0_debug \
  --route gps0:gps0_gpsd \
  --route gps0:gps0_data \
  --route gps0:gps0_debug \
  --route gps0_debug:gps0
```

The intention is for `/dev/gps0_gpsd` and `/dev/gps0_data` to be actively read from during normal operations, and `/dev/gps0_debug` should just be available in case I want to monitor the GPS data or send commands to it.

This works well for a few seconds, but after some time `vsp-router` blocks on trying to write to `gps0_debug` which is not actively being read from. When this happens new data stop being sent to all virtual serial ports, including the ones that are actively being read from.
This is due to the fact that data written to a PTS are being buffered until around ~20kB of data (enforced by the kernel), then new writes are blocked by the kernel until some data is read.
When reading again from `gps0_debug` data streaming resumes on all virtual serial ports, and `vsp-router` also proceeds to send all data that was accumulated during the block to all virtual serial ports.

This is causing me some issues:
- If one virtual serial port is not being read from, intentionally or because the program reading from it crashes, I still want data to be sent to other serial ports
- When reading resumes I do not care about receiving the data that was not being sent during the block as it is stale data

I address those issues in this PR: when a virtual serial port is not being read from, up to ~20kB of data will be accumulated and they will be returned at the next read. New data past those ~20kB will be discarded with a warning message in the logs, but without blocking the other virtual serial ports.

When reading from a virtual serial port, up to ~20kB of stale data will be returned, followed by new data. This behavior is different from a physical serial port which does not buffer data, but it is easy to control from services opening the virtual serial ports by running `tcflush` with the queue selector `TCIFLUSH` on the file descriptor corresponding to the virtual serial port before attempting to read data from it. This way only new data will be returned, the buffered data will be discarded.
For example `gpsd` correctly does a `tcflush` when opening serial ports.

Applying this PR to `vsp-router` and doing the `tcflush` from client services results in reads from virtual serial ports behaving as close as possible as reads from physical serial ports. I suggest adding this information about `tcflush` somewhere as it is really useful when combined with `vsp-router`.

Note that I am very new at Rust, feel free to rewrite the code as you see fit if you want to accept this PR.